### PR TITLE
Fixing invalid webroot saved in server.json

### DIFF
--- a/scripts/200-commandbox.sh
+++ b/scripts/200-commandbox.sh
@@ -37,6 +37,6 @@ cfconfig_adminPassword=$ADMIN_PASSWORD
 export cfconfig_adminPassword
 
 echo "Starting up CommandBox instance"
-box server start name=default port=8080 host=127.0.1.1 cfengine=$CF_ENGINE serverConfigFile=$WEB_ROOT/server.json directory=$WEB_ROOT rewritesEnable=$REWRITES_ENABLED openbrowser=false saveSettings=true --force;
+box server start name=default port=8080 host=127.0.1.1 cfengine=$CF_ENGINE serverConfigFile=$WEB_ROOT/server.json webroot=$WEB_ROOT rewritesEnable=$REWRITES_ENABLED openbrowser=false saveSettings=true --force;
 
 unset cfconfig_adminPassword


### PR DESCRIPTION
This resolves the issue of the server pointing to the wrong webroot after a reboot.

"directory" is not a valid config. It should have been "webroot". Since webroot wasn't defined, it was defaulting to "/"